### PR TITLE
add missing plugin in order to build

### DIFF
--- a/02_create_android_app.md
+++ b/02_create_android_app.md
@@ -339,6 +339,8 @@ class MainActivity : AppCompatActivity() {
 Under **Gradle Scripts**, open **build.gradle (Module:app)** and verify that the generated dependencies are correct.The `libraries versions` need to be checked.
 
 ```gradle
+apply plugin: 'kotlin-android-extensions'
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"


### PR DESCRIPTION
As discussed by mail, I had an issue on step 02 as my `build.gradle` which does not look like yours. I installed Android Studio following the pre-requisite step. 

Here is the error why my build fails
<img width="623" alt="image" src="https://user-images.githubusercontent.com/17109312/96481432-ca387480-123b-11eb-9e4e-fe075d66f07e.png">

Following is my gradle as generated by Android Studio. In a project, i'd add the missing plugin with the others in the beginning of file. But here, for simplicity purpose, the attendee can just copy/paste the changes reflected in the code section.

`plugins {
    id 'com.android.application'
    id 'kotlin-android'
}

android {
    compileSdkVersion 30
    buildToolsVersion "30.0.2"

    defaultConfig {
        applicationId "com.example.androidgettingstarted"
        minSdkVersion 26
        targetSdkVersion 30
        versionCode 1
        versionName "1.0"

        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
    }

    buildTypes {
        release {
            minifyEnabled false
            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
        }
    }
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
    kotlinOptions {
        jvmTarget = '1.8'
    }
}

dependencies {

    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
    implementation 'androidx.core:core-ktx:1.3.2'
    implementation 'androidx.appcompat:appcompat:1.2.0'
    implementation 'com.google.android.material:material:1.2.1'
    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.0'
    implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
    testImplementation 'junit:junit:4.+'
    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
}`