### PR TITLE
not removing _24

### DIFF
--- a/04_add_authentication.md
+++ b/04_add_authentication.md
@@ -214,13 +214,13 @@ The remaining code change tracks the status of user (are they signed in or not?)
         android:layout_alignParentRight="true"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_baseline_lock"
+        android:src="@drawable/ic_baseline_lock_24"
         app:fabCustomSize="60dp"
         app:fabSize="auto"
         />
     ```
 
-    Add a lock icon under `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Chose the lock icon from the clipart and enter **ic_baseline_lock** (without the _24) as name. Click **Next** and **Finish**.
+    Add a lock icon under `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Chose the lock icon from the clipart and enter **ic_baseline_lock_24** as name. Click **Next** and **Finish**.
 
     Repeat the same with the open lock icon.
 
@@ -243,10 +243,10 @@ The remaining code change tracks the status of user (are they signed in or not?)
             val authButton = view as FloatingActionButton
 
             if (userData.isSignedIn.value!!) {
-                authButton.setImageResource(R.drawable.ic_baseline_lock_open)
+                authButton.setImageResource(R.drawable.ic_baseline_lock_open_24)
                 Backend.signOut()
             } else {
-                authButton.setImageResource(R.drawable.ic_baseline_lock_open)
+                authButton.setImageResource(R.drawable.ic_baseline_lock_open_24)
                 Backend.signIn(this)
             }
         }
@@ -263,9 +263,9 @@ The remaining code change tracks the status of user (are they signed in or not?)
         Log.i(TAG, "isSignedIn changed : $isSignedUp")
 
         if (isSignedUp) {
-            fabAuth.setImageResource(R.drawable.ic_baseline_lock_open)
+            fabAuth.setImageResource(R.drawable.ic_baseline_lock_open_24)
         } else {
-            fabAuth.setImageResource(R.drawable.ic_baseline_lock)
+            fabAuth.setImageResource(R.drawable.ic_baseline_lock_24)
         }
     })
     ```

--- a/05_add_api_database.md
+++ b/05_add_api_database.md
@@ -407,12 +407,12 @@ Now that the backend and data model pieces are in place, the last step in this s
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
         android:visibility="invisible"
-        android:src="@drawable/ic_baseline_post_add"
+        android:src="@drawable/ic_baseline_post_add_24"
         app:fabCustomSize="60dp"
         app:fabSize="auto"/>
     ```
 
-    Add a "Add Note" icon in `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Enter **ic_baseline_add** as name and chose the add icon from the Clip Art. Click **Next** and **Finish**.
+    Add a "Add Note" icon in `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Enter **ic_baseline_post_add_24** as name and chose the add icon from the Clip Art. Click **Next** and **Finish**.
 
     ![android studio create add note icon](img/05_20.png)
 
@@ -438,12 +438,12 @@ Now that the backend and data model pieces are in place, the last step in this s
 
         //animation inspired by https://www.11zon.com/zon/android/multiple-floating-action-button-android.php
         if (isSignedUp) {
-            fabAuth.setImageResource(R.drawable.ic_baseline_lock_open)
+            fabAuth.setImageResource(R.drawable.ic_baseline_lock_open_24)
             Log.d(TAG, "Showing fabADD")
             fabAdd.show()
             fabAdd.animate().translationY(0.0F - 1.1F * fabAuth.customSize)
         } else {
-            fabAuth.setImageResource(R.drawable.ic_baseline_lock)
+            fabAuth.setImageResource(R.drawable.ic_baseline_lock_24)
             Log.d(TAG, "Hiding fabADD")
             fabAdd.hide()
             fabAdd.animate().translationY(0.0F)
@@ -489,7 +489,7 @@ The swipe-to-delete behavior can be added by adding a touch handler to the list 
         private val TAG: String = "SimpleItemTouchCallback"
         private val icon: Drawable? = ContextCompat.getDrawable(
             activity,
-            R.drawable.ic_baseline_delete_sweep
+            R.drawable.ic_baseline_delete_sweep_24
         )
         private val background: ColorDrawable = ColorDrawable(Color.RED)
 
@@ -562,7 +562,7 @@ The swipe-to-delete behavior can be added by adding a touch handler to the list 
 
     The important lines of code are in the `onSwiped()` method. This method is called when the swipe gesture finishes. We collect the position in the list for the swiped item, and we remove the corresponding note from the `UserData` structure (this updates the UI) and from the cloud backend.
 
-2. Now that we have a class, let's add a "Delete" icon in `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Enter **ic_baseline_delete_sweep** as name and chose the "delete sweep" icon from the Clip Art. Click **Next** and **Finish**.
+2. Now that we have a class, let's add a "Delete" icon in `res/drawable`. Right click `drawable`, select **New**, then **Vector Asset**. Enter **ic_baseline_delete_sweep_24** as name and chose the "delete sweep" icon from the Clip Art. Click **Next** and **Finish**.
 
     ![android studio create add note icon](img/05_45.png)
 

--- a/code/app/src/main/java/com/example/androidgettingstarted/MainActivity.kt
+++ b/code/app/src/main/java/com/example/androidgettingstarted/MainActivity.kt
@@ -24,12 +24,12 @@ class MainActivity : AppCompatActivity() {
 
             //animation inspired by https://www.11zon.com/zon/android/multiple-floating-action-button-android.php
             if (isSignedUp) {
-                fabAuth.setImageResource(R.drawable.ic_baseline_lock_open)
+                fabAuth.setImageResource(R.drawable.ic_baseline_lock_open_24)
                 Log.d(TAG, "Showing fabADD")
                 fabAdd.show()
                 fabAdd.animate().translationY(0.0F - 1.1F * fabAuth.customSize)
             } else {
-                fabAuth.setImageResource(R.drawable.ic_baseline_lock)
+                fabAuth.setImageResource(R.drawable.ic_baseline_lock_24)
                 Log.d(TAG, "Hiding fabADD")
                 fabAdd.hide()
                 fabAdd.animate().translationY(0.0F)
@@ -63,10 +63,10 @@ class MainActivity : AppCompatActivity() {
             val authButton = view as FloatingActionButton
 
             if (userData.isSignedIn.value!!) {
-                authButton.setImageResource(R.drawable.ic_baseline_lock_open)
+                authButton.setImageResource(R.drawable.ic_baseline_lock_open_24)
                 Backend.signOut()
             } else {
-                authButton.setImageResource(R.drawable.ic_baseline_lock_open)
+                authButton.setImageResource(R.drawable.ic_baseline_lock_open_24)
                 Backend.signIn(this)
             }
         }

--- a/code/app/src/main/java/com/example/androidgettingstarted/SwipeCallback.kt
+++ b/code/app/src/main/java/com/example/androidgettingstarted/SwipeCallback.kt
@@ -21,7 +21,7 @@ class SwipeCallback(private val activity: AppCompatActivity): ItemTouchHelper.Si
     private val TAG: String = "SimpleItemTouchCallback"
     private val icon: Drawable? = ContextCompat.getDrawable(
         activity,
-        R.drawable.ic_baseline_delete_sweep
+        R.drawable.ic_baseline_delete_sweep_24
     )
     private val background: ColorDrawable = ColorDrawable(Color.RED)
 

--- a/code/app/src/main/res/layout/activity_main.xml
+++ b/code/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
         android:visibility="invisible"
-        android:src="@drawable/ic_baseline_post_add"
+        android:src="@drawable/ic_baseline_post_add_24"
         app:fabCustomSize="60dp"
         app:fabSize="auto"/>
 
@@ -41,7 +41,7 @@
         android:layout_alignParentRight="true"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_baseline_lock"
+        android:src="@drawable/ic_baseline_lock_24"
         app:fabCustomSize="60dp"
         app:fabSize="auto"
         />


### PR DESCRIPTION
When adding a vector asset with Android Studio, the name is auto generated by the IDE. The _24 is included in the generated name. As there's not real value added in the tutorial by removing this step, i've removed it. 